### PR TITLE
Make args explicit in signatures.

### DIFF
--- a/src/tomocupy_stream/rec.py
+++ b/src/tomocupy_stream/rec.py
@@ -49,70 +49,220 @@ __copyright__ = "Copyright (c) 2023, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 __all__ = ['GPURecRAM', ]
 
-class GPURecRAM():
+class GPURecRAM:
     '''
     Class for tomographic reconstruction on GPU with conveyor data processing by sinogram chunks (in z direction).
     CUDA Streams are used to overlap CPU-GPU data transfers with computations.    
     '''
 
-    def __init__(self, args, theta):                
+    @classmethod
+    def for_data_like(
+        cls,
+        *,
+        data,
+        dark,
+        flat,
+        ncz,
+        dtype,
+        rotation_axis,
+        reconstruction_algorithm="fourierrec",
+        remove_stripe_method="None",
+        fw_sigma=None,
+        fw_filter=None,
+        fw_level=None,
+        ti_beta=None,
+        ti_mask=None,
+        dezinger=0,
+        dezinger_threshold=5000,
+        fbp_filter="parzen",
+    ):
+        """
+        Construct a GPURecRAM instance from sample data.
+        """
+        return cls(
+            n=data.shape[2],
+            nz=data.shape[1],
+            nproj=data.shape[0],
+            ncz=ncz,
+            ndark=dark.shape[0],
+            nflat=flat.shape[0],
+            in_dtype=data.dtype,
+            dtype=dtype,
+            rotation_axis=rotation_axis,
+            reconstruction_algorithm=reconstruction_algorithm,
+            remove_stripe_method=remove_stripe_method,
+            fw_sigma=fw_sigma,
+            fw_filter=fw_filter,
+            fw_level=fw_level,
+            ti_beta=ti_beta,
+            ti_mask=ti_mask,
+            dezinger=dezinger,
+            dezinger_threshold=dezinger_threshold,
+            fbp_filter=fbp_filter,
+        )
+
+
+    def __init__(
+        self,
+        *,
+        n,
+        nz,
+        nproj,
+        ncz,
+        ndark,
+        nflat,
+        in_dtype,
+        dtype,
+        rotation_axis,
+        reconstruction_algorithm="fourierrec",
+        remove_stripe_method="None",
+        fw_sigma=None,
+        fw_filter=None,
+        fw_level=None,
+        ti_beta=None,
+        ti_mask=None,
+        dezinger=0,
+        dezinger_threshold=5000,
+        fbp_filter="parzen",
+    ):
+        """
+        n : int
+            Smaple size in x
+        nz : int
+            Sample size in z
+        nproj : int
+            Number of projection angles
+        ncz : int
+            Chunk size (must be multiple of 2)
+        ndark : int
+            Number of dark fields
+        nflat : int
+            Number of flat fields
+        in_dtype : numpy.dtype or str
+            Input data type
+        dtype : numpy.dtype or str
+            Output data type
+        rotation_axis : float
+        reconstruction_algorithm : {"fourierrec", "lprec", "linerec"}
+        remove_stripe_method : {"fw", "ti"}
+        fw_sigma : float
+            Only applicable if remove_stripe_method="fw"
+        fw_filter :
+            Only applicable if remove_stripe_method="fw"
+        fw_level : float
+            Only applicable if remove_stripe_method="fw"
+        ti_beta : float
+            Only applicable if remove_stripe_method="ti"
+        ti_mask : float
+            Only applicable if remove_stripe_method="ti"
+        dezinger : int
+            0 means no zingers; 2 means remove zingers
+        dezinger_threshold : float
+        fbp_filter :
+            Default is "parzen"
+
+        """
+        if (ncz % 2 != 0):
+            raise ValueError("Chunk size must be a multiple of 2")
         
-        self.shape_data_chunk = (args.ncz, args.nproj, args.n)
-        self.shape_recon_chunk = (args.ncz, args.n, args.n)
-        self.shape_dark_chunk = (args.ndark, args.ncz, args.n)
-        self.shape_flat_chunk = (args.nflat, args.ncz, args.n)
+        self.n = n
+        self.nz = nz
+        self.nproj = nproj
+        self.ncz = ncz
+        self.ndark = ndark
+        self.nflat = nflat
+        self.dtype = dtype
+        self.shape_data_chunk = (ncz, nproj, n)
+        self.shape_recon_chunk = (ncz, n, n)
+        self.shape_dark_chunk = (ndark, ncz, n)
+        self.shape_flat_chunk = (nflat, ncz, n)
+        self.tomofunc_kwargs = dict(
+            n=n,
+            nproj=nproj,
+            ncz=ncz,
+            dtype=dtype,
+            rotation_axis=rotation_axis,
+            reconstruction_algorithm=reconstruction_algorithm,
+            remove_stripe_method=remove_stripe_method,
+            fw_sigma=fw_sigma,
+            fw_filter=fw_filter,
+            fw_level=fw_level,
+            ti_beta=ti_beta,
+            ti_mask=ti_mask,
+            dezinger=dezinger,
+            dezinger_threshold=dezinger_threshold,
+            fbp_filter=fbp_filter,
+        )
         
         # pinned memory for data item
         self.item_pinned = {}
-        self.item_pinned['data'] = utils.pinned_array(np.zeros([2, *self.shape_data_chunk], dtype=args.in_dtype))
-        self.item_pinned['dark'] = utils.pinned_array(np.zeros([2, *self.shape_dark_chunk], dtype=args.in_dtype))
-        self.item_pinned['flat'] = utils.pinned_array(np.ones([2, *self.shape_flat_chunk], dtype=args.in_dtype))
+        self.item_pinned['data'] = utils.pinned_array(np.zeros([2, *self.shape_data_chunk], dtype=in_dtype))
+        self.item_pinned['dark'] = utils.pinned_array(np.zeros([2, *self.shape_dark_chunk], dtype=in_dtype))
+        self.item_pinned['flat'] = utils.pinned_array(np.ones([2, *self.shape_flat_chunk], dtype=in_dtype))
 
         # gpu memory for data item
         self.item_gpu = {}
-        self.item_gpu['data'] = cp.zeros([2, *self.shape_data_chunk], dtype=args.in_dtype)
-        self.item_gpu['dark'] = cp.zeros([2, *self.shape_dark_chunk], dtype=args.in_dtype)
-        self.item_gpu['flat'] = cp.ones([2, *self.shape_flat_chunk], dtype=args.in_dtype)
+        self.item_gpu['data'] = cp.zeros([2, *self.shape_data_chunk], dtype=in_dtype)
+        self.item_gpu['dark'] = cp.zeros([2, *self.shape_dark_chunk], dtype=in_dtype)
+        self.item_gpu['flat'] = cp.ones([2, *self.shape_flat_chunk], dtype=in_dtype)
 
         # pinned memory for reconstrution
-        self.rec_pinned = utils.pinned_array(np.zeros([16,*self.shape_recon_chunk], dtype=args.dtype))
+        self.rec_pinned = utils.pinned_array(np.zeros([16,*self.shape_recon_chunk], dtype=dtype))
 
         # gpu memory for reconstrution
-        self.rec_gpu = cp.zeros([2, *self.shape_recon_chunk], dtype=args.dtype)
+        self.rec_gpu = cp.zeros([2, *self.shape_recon_chunk], dtype=dtype)
                 
         # chunks        
-        self.nzchunk = int(np.ceil(args.nz/args.ncz))
+        self.nzchunk = int(np.ceil(nz/ncz))
         self.lzchunk = np.minimum(
-            args.ncz, np.int32(args.nz-np.arange(self.nzchunk)*args.ncz))  # chunk sizes        
-        self.ncz = args.ncz
-        self.nz = args.nz
+            ncz, np.int32(nz-np.arange(self.nzchunk)*ncz))  # chunk sizes        
+        self.ncz = ncz
+        self.nz = nz
         
         # streams for overlapping data transfers with computations
         self.stream1 = cp.cuda.Stream(non_blocking=False)
         self.stream2 = cp.cuda.Stream(non_blocking=False)
         self.stream3 = cp.cuda.Stream(non_blocking=False)
         
-        self.cl_tomo_func = tomo_functions.TomoFunctions(args,theta)
-        
         # threads for filling the resulting array
         self.write_threads = []
         for k in range(16):#16 is probably enough but can be changed
             self.write_threads.append(utils.WRThread())
         
-    def recon_all(self, result, data_in, dark_in, flat_in):
+    def recon_all(self, data, dark, flat, theta, output=None):
+        # Validate that the inputs match what was declared in __init__ and pre-allocated for.
+        expected_data_shape = (self.nz, self.nproj, self.n)
+        if data.shape != expected_data_shape:
+            raise ValueError(f"Expected data.shape {expected_data_shape}, got {data.shape}")
+        expected_dark_shape = (self.ndark, self.nz, self.n)
+        if dark.shape != expected_dark_shape:
+            raise ValueError(f"Expected dark.shape {expected_dark_shape}, got {dark.shape}")
+        expected_flat_shape = (self.nflat, self.nz, self.n)
+        if flat.shape != expected_flat_shape:
+            raise ValueError(f"Expected flat.shape {expected_flat_shape}, got {flat.shape}")
+        if output is None:
+            # Allocate output array.
+            output = np.zeros([self.nz, self.n, self.n], dtype=self.dtype)
+        else:
+            # Use pre-allocated output array, first validating it.
+            expected_output_shape = (self.nz, self.n, self.n)
+            if output.shape != expected_output_shape:
+                raise ValueError(f"Expected output.shape {expected_output_shape}, got {output.shape}")
                 
+        self.cl_tomo_func = tomo_functions.TomoFunctions(theta=theta, **self.tomofunc_kwargs)
+        
         # Pipeline for data cpu-gpu copy and reconstruction
         for k in range(self.nzchunk+2):
             if k<self.nzchunk:
                 utils.printProgressBar(k, self.nzchunk, length=40)
             if(k > 0 and k < self.nzchunk+1):
                 with self.stream2:  # reconstruction
-                    data = self.item_gpu['data'][(k-1) % 2]
-                    dark = self.item_gpu['dark'][(k-1) % 2]
-                    flat = self.item_gpu['flat'][(k-1) % 2]
+                    data_chunk = self.item_gpu['data'][(k-1) % 2]
+                    dark_chunk = self.item_gpu['dark'][(k-1) % 2]
+                    flat_chunk = self.item_gpu['flat'][(k-1) % 2]
                     
                     rec = self.rec_gpu[(k-1) % 2]                    
-                    self.cl_tomo_func.rec(rec, data, dark, flat)
+                    self.cl_tomo_func.rec(rec, data_chunk, dark_chunk, flat_chunk)
                     
             if(k > 1):
                 with self.stream3:  # gpu->cpu copy
@@ -122,9 +272,9 @@ class GPURecRAM():
                     
             if(k < self.nzchunk):
                 # copy to pinned memory
-                self.item_pinned['data'][k % 2, :self.lzchunk[k]] = data_in[k*self.ncz:k*self.ncz+self.lzchunk[k]]
-                self.item_pinned['dark'][k % 2, :, :self.lzchunk[k]] = dark_in[:,k*self.ncz:k*self.ncz+self.lzchunk[k]]
-                self.item_pinned['flat'][k % 2, :, :self.lzchunk[k]] = flat_in[:,k*self.ncz:k*self.ncz+self.lzchunk[k]]
+                self.item_pinned['data'][k % 2, :self.lzchunk[k]] = data[k*self.ncz:k*self.ncz+self.lzchunk[k]]
+                self.item_pinned['dark'][k % 2, :, :self.lzchunk[k]] = dark[:,k*self.ncz:k*self.ncz+self.lzchunk[k]]
+                self.item_pinned['flat'][k % 2, :, :self.lzchunk[k]] = flat[:,k*self.ncz:k*self.ncz+self.lzchunk[k]]
                 
                 
                 with self.stream1:  # cpu->gpu copy
@@ -136,11 +286,11 @@ class GPURecRAM():
                 # run a thread filling the resulting array (after gpu->cpu copy is done)
                 st = (k-2)*self.ncz
                 end = st+self.lzchunk[k-2]
-                self.write_threads[ithread].run(utils.fill_array, (result, self.rec_pinned[ithread], st, end))
+                self.write_threads[ithread].run(utils.fill_array, (output, self.rec_pinned[ithread], st, end))
 
             self.stream1.synchronize()
             self.stream2.synchronize()
             
         for t in self.write_threads:
             t.join()
-            
+        return output 

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -1,0 +1,33 @@
+from tomocupy_stream import GPURecRAM
+import numpy as np
+import tifffile
+import time
+
+
+in_dtype = "uint8"  # input data type
+dtype = "float32"  # output data type
+n = 2048  # sample size in x
+nz = 2048  # sample size in z
+nproj = 2048  # number of projection angles
+ndark = 10  # number of dark fields
+nflat = 10  # number of flat fields
+
+# init data, dark, flat, theta
+data = np.zeros([nz, nproj, n], dtype=in_dtype)
+data[:, :, n // 2] = 32
+dark = np.zeros([ndark, nz, n], dtype=in_dtype)
+flat = np.ones([nflat, nz, n], dtype=in_dtype) + 64
+theta = np.linspace(0, 180, nproj, endpoint=False).astype("float32")
+
+
+cl = GPURecRAM.for_data_like(
+    data=data,
+    dark=dark,
+    flat=flat,
+    ncz=8,  # chunk size (multiple of 2)
+    rotation_axis=2048 / 2,  # rotation center
+    dtype="float32",  # computation type, note  for float16 n should be a power of 2
+)
+t = time.time()
+result = cl.recon_all(data, dark, flat, theta)
+print(f"Reconstruction time: {time.time()-t}s")

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -4,58 +4,57 @@ import tifffile
 import time
 
 
-################ a structure of parameters (should be done in a nicer way)
-class args:
-    pass
-
-args.n = 2048 # sample size in x
-args.nz = 2048 # sample size in z
-args.nproj = 2048 # number of projection angles
-args.ncz = 8 # chunk size (multiple of 2)
-args.ndark = 10 # number of dark fields
-args.nflat = 10 # number of flat fields
-args.in_dtype = 'uint8' # input data type
-args.dtype = 'float32' # computation type, note  for float16 n should be a power of 2
-args.reconstruction_algorithm = 'fourierrec' # fourierrec, lprec, or linerec
-
-args.dezinger = 0 # zinger size (0 - no zingers)
-# args.dezinger = 2 # removing Zingers
-# args.dezinger_threshold = 5000
-
-args.remove_stripe_method = 'None'
-# args.remove_stripe_method = 'fw'
-# args.fw_sigma = 1
-# args.fw_level = 7
-# args.fw_filter = 'sym16'
-
-# args.remove_stripe_method = 'ti'
-# args.ti_beta = 0.022
-# args.ti_mask = 1.0
-
-args.fbp_filter = 'parzen' # filter for fbp
-args.rotation_axis = args.n/2 # rotation center
-#####################################################
-
-
-
-
+in_dtype = 'uint8'  # input data type
+dtype = 'float32'  # output data type
+n = 2048  # sample size in x
+nz = 2048  # sample size in z
+nproj = 2048  # number of projection angles
+ndark = 10  # number of dark fields
+nflat = 10  # number of flat fields
 
 # init data, dark, flat, theta
-data = np.zeros([args.nz,args.nproj,args.n],dtype=args.in_dtype)
-data[:,:,args.n//2] = 32
-dark = np.zeros([args.ndark,args.nz,args.n],dtype=args.in_dtype)
-flat = np.ones([args.nflat,args.nz,args.n],dtype=args.in_dtype)+64
-theta = np.linspace(0,180,args.nproj,endpoint=False).astype('float32')
+data = np.zeros([nz,nproj,n],dtype=in_dtype)
+data[:,:,n//2] = 32
+dark = np.zeros([ndark,nz,n],dtype=in_dtype)
+flat = np.ones([nflat,nz,n],dtype=in_dtype)+64
+theta = np.linspace(0,180,nproj,endpoint=False).astype('float32')
 
 # memory for result
-result = np.zeros([args.nz,args.n,args.n],dtype=args.dtype)
+result = np.zeros([nz,n,n],dtype=dtype)
 
 # create reconstruction class (preallocate memory, init grids for backprojection)
 # can be done once 
-cl = GPURecRAM(args, theta)
+cl = GPURecRAM(
+    n = n,
+    nz = nz,
+    nproj = nproj,
+    ncz = 8,  # chunk size (multiple of 2)
+    ndark = ndark,
+    nflat = nflat,
+    in_dtype = in_dtype,
+    dtype = 'float32',  # computation type, note  for float16 n should be a power of 2
+    reconstruction_algorithm = 'fourierrec',  # fourierrec, lprec, or linerec
+
+    dezinger = 0, # zinger size (0 - no zingers)
+    # dezinger = 2, # removing Zingers
+    # dezinger_threshold = 5000,
+
+    remove_stripe_method = 'None',
+    # remove_stripe_method = 'fw',
+    # fw_sigma = 1,
+    # fw_level = 7,
+    # fw_filter = 'sym16',
+
+    # remove_stripe_method = 'ti',
+    # ti_beta = 0.022,
+    # ti_mask = 1.0,
+
+    fbp_filter = 'parzen',  # filter for fbp
+    rotation_axis = 2048 / 2, # rotation center
+)
 # run recon
 t = time.time()
-cl.recon_all(result,data,dark,flat)
+cl.recon_all(data, dark, flat, theta, output=result)
 print(f'Reconstruction time: {time.time()-t}s')
 
 # save recon

--- a/tests/test_rec.py
+++ b/tests/test_rec.py
@@ -4,43 +4,6 @@ import numpy as np
 import tifffile
 
 
-
-################ a structure of parameters (should be done in a nicer way)
-class args:
-    pass
-
-args.n = 1536 # sample size in x
-args.nz = 22 # sample size in z
-args.nproj = 720 # number of projection angles
-args.ncz = 4 # chunk size (multiple of 2)
-args.ndark = 10 # number of dark fields
-args.nflat = 20 # number of flat fields
-args.in_dtype = 'uint16' # input data type
-args.dtype = 'float32' # computation type, note  for float16 n should be a power of 2
-args.reconstruction_algorithm = 'fourierrec' # fourierrec, lprec, or linerec
-
-args.dezinger = 0 # zinger size (0 - no zingers)
-# args.dezinger = 2 # removing Zingers
-# args.dezinger_threshold = 5000
-
-args.remove_stripe_method = 'None'
-# args.remove_stripe_method = 'fw'
-# args.fw_sigma = 1
-# args.fw_level = 7
-# args.fw_filter = 'sym16'
-
-# args.remove_stripe_method = 'ti'
-# args.ti_beta = 0.022
-# args.ti_mask = 1.0
-
-args.fbp_filter = 'parzen' # filter for fbp
-args.rotation_axis = 782.5 # rotation center
-#####################################################
-
-
-
-
-
 # init data, dark, flat, theta
 with h5py.File('data/test_data.h5','r') as fid:        
     data = fid['/exchange/data'][:,:,:]
@@ -48,16 +11,41 @@ with h5py.File('data/test_data.h5','r') as fid:
     flat = fid['/exchange/data_white'][:]
     theta = fid['/exchange/theta'][:]
 data = data.swapaxes(0,1)# note: sinogram shape
-# memory for result
-result = np.zeros([args.nz,args.n,args.n],dtype=args.dtype)
 
 # create reconstruction class (preallocate memory, init grids for backprojection)
 # can be done once 
-cl = GPURecRAM(args, theta)
+cl = GPURecRAM(
+    n = 1536,  # sample size in x
+    nz = 22,  # sample size in z
+    nproj = 720,  # number of projection angles
+    ncz = 4,  # chunk size (multiple of 2)
+    ndark = 10,  # number of dark fields
+    nflat = 20,  # number of flat fields
+    in_dtype = 'uint16',  # input data type
+    dtype = 'float32',  # computation type, note  for float16 n should be a power of 2
+    reconstruction_algorithm = 'fourierrec',  # fourierrec, lprec, or linerec
+    
+    dezinger = 0,  # zinger size (0 - no zingers)
+    # dezinger = 2,  # removing Zingers
+    # dezinger_threshold = 5000,
+   
+   remove_stripe_method = 'None',
+    # remove_stripe_method = 'fw',
+    # fw_sigma = 1,
+    # fw_level = 7,
+    # fw_filter = 'sym16',
+   
+    # remove_stripe_method = 'ti',
+    # ti_beta = 0.022,
+    # ti_mask = 1.0,
+    
+    fbp_filter = 'parzen',  # filter for fbp
+    rotation_axis = 782.5,  # rotation center
+)
 
 # run recon
-cl.recon_all(result,data,dark,flat)
+result = cl.recon_all(data, dark, flat, theta)
 
 # save recon
 print(np.linalg.norm(result))
-tifffile.imwrite('data/result.tiff',result)    
+tifffile.imwrite('data/result.tiff',result)


### PR DESCRIPTION
As proposed over email, I offer this possible way to make the flow of parameters through the program easier to follow. Spelling out the parameters in the `__init__` is more _verbose_ than a bundle of `args` but to my eye it is less complex. It lets me quickly answer questions like "Which parameters are required to construct `GPURecRAM`?" and "Which parameters flow down into `TomoFunctions`"? Python will also help us by failing fast with a `TypeError` if required arguments are missing or if extraneous (perhaps misspelled) arguments are given.

Additional notable changes:

* The `theta` array was being passed in `__init__` but it was not being used until `recon_all`. The parameters has been moved there.
* Following a convention used by many functions in scipy, the output array _may_ be pre-allocated and passed into to `recon_all` but if it is omitted, a suitable output array is automatically constructed. In either case, the output array is returned.
* A convenience classmethod constructor `GPURecRAM.for_data_like(...)` is added an alternative way to create a `GPURecRAM` instance .It extracts various shape parameters (`n`, `nz`, `ndark`, etc.) by inspecting input data. As demonstrated in `test_minimal.py`, this enables a more succinct usage. The underlying `GPURecRAM__init__` is still available for more explicit construction and/or construction before any data array is available.

The tests `test_rec.py` and `test_perf.py`, as well as the new `test_minimal.py`, pass on this branch. I have also visually inspected the output of `test_rec.py` and confirmed that it is byte-identical to the version produced by the `main` branch:

```
$ md5sum result_before.tiff result_after.tiff 
be528504081d13c32070a7c7f1a78316  result_before.tiff  # written by main branch
be528504081d13c32070a7c7f1a78316  result_after.tiff  # written by this PR branch
```