### PR TITLE
Fixes for NSLS2

### DIFF
--- a/src/tomocupy_stream/find_center.py
+++ b/src/tomocupy_stream/find_center.py
@@ -85,7 +85,7 @@ def _calculate_metric(shift_col, sino1, sino2, sino3, mask):
             sino_shift[:, shift_col:] = sino3[:, shift_col:]
         mat = cp.vstack((sino1, sino_shift))
     else:
-        sino_shift = ndimage.interpolation.shift(
+        sino_shift = ndimage.shift(
             sino2, (0, shift_col), order=3, prefilter=True)
         if shift_col >= 0:
             shift_int = int(np.ceil(shift_col))

--- a/src/tomocupy_stream/find_center.py
+++ b/src/tomocupy_stream/find_center.py
@@ -67,8 +67,8 @@ def find_center_vo(tomo, dark, flat, ind=None, smin=-50, smax=50, srad=6, step=0
 
 def _downsample(tomo, level):
     for k in range(level):
-        tomo = 0.5*(tomo[::2]+tomo[1::2])
-        tomo = 0.5*(tomo[:,::2]+tomo[:,1::2])
+        tomo = 0.5*(tomo[:-1:2]+tomo[1::2])
+        tomo = 0.5*(tomo[:,:-1:2]+tomo[:,1::2])
     return tomo        
     
 def _calculate_metric(shift_col, sino1, sino2, sino3, mask):


### PR DESCRIPTION
Two unrelated fixes:

1. One of our test data sets has 899 projections, and I suspect this code only works with a number of projections that happens to be even.
2. I got the error `AttributeError: module 'cupyx.scipy.ndimage' has no attribute 'interpolation'`. It looks like the module `ndimage` was made private in [this commit of cupy, in February 2022](https://github.com/cupy/cupy/commit/e194e16ef1c31d8bef3d8ff613c18a817460338b). With this change, the code runs for me on cupy version 12.0.0.

With that, the center-finding integrates wonderfully. We can look up a data set (by scan ID, for example) in our data service, load it directly from the network into numpy, and then use tomocupy-stream for both center-finding and reconstruction:

```
13:45 dallan@mars1:scripts [tiled-recon !?]$ python tiled_recon.py 3909534a-1cb8-40f8-b8a3-f9247258f6a4 -p center.tiff -c /mnt/ramdisk/tiled_cache
[########################################] | 100% Completed | 601.82 ms
[########################################] | 100% Completed | 101.31 ms
[########################################] | 100% Completed | 100.72 ms
[########################################] | 100% Completed | 100.97 ms
[########################################] | 100% Completed | 100.65 ms
[########################################] | 100% Completed | 100.63 ms
inputs.data.shape = (2160, 900, 2560) (z, proj, x) uint16 
inputs.dark.shape = (20, 2160, 2560) (num_dark, z, x) uint16 
inputs.flat.shape = (20, 2160, 2560) (num_flat, z, x) uint16 
inputs.theta.shape = (900,) (proj,) float32 
Data loading time: 5.68s
Center-finding time: 5.82s
Found rotation axis: 1316.750
chunk 270/270 |  |████████████████████████████████████████| 100.0% 
Theta stats: inputs.theta.min() = 0.8558904 inputs.theta.max() = 180.0
Result stats: result.min() = -0.0057423483 result.max() = 0.005828619 np.isfinite(result).all() = True
Reconstruction time: 19.14s
Writing center recon to center.tiff
```