### PR TITLE
Dev

### DIFF
--- a/src/streamtomocupy/retrieve_phase.py
+++ b/src/streamtomocupy/retrieve_phase.py
@@ -47,9 +47,8 @@ def paganin_filter(
     ndarray
         Approximated 3D tomographic phase data.
     """
-
     # New dimensions and pad value after padding.
-    py, pz, val = _calc_pad(data, pixel_size, dist, energy, pad)
+    py, pz = _calc_pad(data, pixel_size, dist, energy, pad)
 
     # Compute the reciprocal grid.
     dx, dy, dz = data.shape
@@ -62,7 +61,8 @@ def paganin_filter(
         phase_filter = cp.fft.fftshift(
             _paganin_filter_factorG(energy, dist, kf, pixel_size, db, W))
 
-    prj = cp.full((dy + 2 * py, dz + 2 * pz), val, dtype=data.dtype)
+    prj = cp.empty([dy + 2 * py, dz + 2 * pz], dtype=data.dtype)
+    
     _retrieve_phase(data, phase_filter, py, pz, prj, pad)
 
     return data
@@ -71,14 +71,10 @@ def paganin_filter(
 def _retrieve_phase(data, phase_filter, px, py, prj, pad):
     dx, dy, dz = data.shape
     num_jobs = data.shape[0]
-    normalized_phase_filter = phase_filter / phase_filter.max()
-
-    for m in range(num_jobs):
-        prj[px:dy + px, py:dz + py] = data[m]
-        prj[:px] = prj[px]
-        prj[-px:] = prj[-px-1]
-        prj[:, :py] = prj[:, py][:, cp.newaxis]
-        prj[:, -py:] = prj[:, -py-1][:, cp.newaxis]
+    normalized_phase_filter = phase_filter / phase_filter.max()    
+    
+    for m in range(num_jobs):        
+        prj[:] = cp.pad(data[m],((px,px),(py,py)),mode='edge')
         fproj = fft2(prj)
         fproj *= normalized_phase_filter
         proj = cp.real(ifft2(fproj))
@@ -115,13 +111,12 @@ def _calc_pad(data, pixel_size, dist, energy, pad):
     """
     dx, dy, dz = data.shape
     wavelength = _wavelength(energy)
-    py, pz, val = 0, 0, 0
+    py, pz, = 0, 0
     if pad:
-        val = _calc_pad_val(data)
         py = _calc_pad_width(dy, pixel_size, wavelength, dist)
         pz = _calc_pad_width(dz, pixel_size, wavelength, dist)
 
-    return py, pz, val
+    return py, pz
 
 
 def _paganin_filter_factor(energy, dist, alpha, w2):
@@ -141,10 +136,6 @@ def _paganin_filter_factorG(energy, dist, kf, pixel_size, db, W):
 def _calc_pad_width(dim, pixel_size, wavelength, dist):
     pad_pix = int(cp.ceil(PI * wavelength * dist / pixel_size ** 2))
     return (2**int(cp.ceil(cp.log2(dim + pad_pix))) - dim) // 2
-
-
-def _calc_pad_val(data):
-    return cp.mean((data[..., 0] + data[..., -1]) * 0.5)
 
 
 def _reciprocal_grid(pixel_size, nx, ny):

--- a/src/streamtomocupy/retrieve_phase.py
+++ b/src/streamtomocupy/retrieve_phase.py
@@ -139,8 +139,8 @@ def _paganin_filter_factorG(energy, dist, kf, pixel_size, db, W):
 
 
 def _calc_pad_width(dim, pixel_size, wavelength, dist):
-    pad_pix = cp.ceil(PI * wavelength * dist / pixel_size ** 2)
-    return int((pow(2, cp.ceil(cp.log2(dim + pad_pix))) - dim) * 0.5)
+    pad_pix = int(cp.ceil(PI * wavelength * dist / pixel_size ** 2))
+    return (2**int(cp.ceil(cp.log2(dim + pad_pix))) - dim) // 2
 
 
 def _calc_pad_val(data):

--- a/src/streamtomocupy/retrieve_phase.py
+++ b/src/streamtomocupy/retrieve_phase.py
@@ -214,7 +214,5 @@ def _reciprocal_coord(pixel_size, num_grid):
     ndarray
         Grid coordinates.
     """
-    n = num_grid - 1
-    rc = cp.arange(-n, num_grid, 2, dtype=cp.float32)
-    rc *= 0.5 / (n * pixel_size)
+    rc = cp.fft.fftshift(cp.fft.fftfreq(num_grid,d=pixel_size))
     return rc

--- a/src/streamtomocupy/streamrecon.py
+++ b/src/streamtomocupy/streamrecon.py
@@ -1,5 +1,6 @@
 import cupy as cp
 import numpy as np
+import sys
 
 from streamtomocupy import rec
 from streamtomocupy import proc
@@ -19,6 +20,9 @@ class StreamRecon():
         in_dtype = args.in_dtype
         ngpus = args.ngpus
         
+        if ni%2 != 0:
+            raise Exception('data size in the last dimension should be even')
+
         if (args.file_type == 'double_fov'):
             n = 2*ni
         else:


### PR DESCRIPTION
Working on fixing this:

In phase.py / retrieve_phase.py:
The _reciprocal_coord function returns coordinates different from np.fft.fftfreq, resulting in a non-conjugated array fproj in _retrieve_phase().
**- switched to using fftfreq**
The padding in retrieve_phase is symmetrical; if any dimension of the original data has an odd length, the padded result remains odd.
**force to using even numbers all time**
The _calc_pad_width function is not numerically stable, especially when using CuPy funcitons. The expression (pow(2, np.ceil(np.log2(dim + pad_pix))) - dim) * 0.5 can yield values like 31.99999, leading to a return value of 31 instead of 32. This function also synchronizes the CUDA stream.
**rewritten properly**
The value returned by _calc_pad_val() doesn’t seem to be used, as _retrieve_phase() performs edge padding instead.
**removed unnecessary variables/functions**
The following issues only affect TomoCupy / StreamTomoCupy:
In backprojection_functions.py, the padding in fbp_filter_center is symmetrical, which can produce inconsistent array shapes when params.n is odd.
**assume that we work with even numbers all time**
